### PR TITLE
implements additional traits for filter types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.2"
+version = "0.3.0"
 authors = [
     "William Brown <william@blackhats.net.au>",
     ]

--- a/proto/src/filter.rs
+++ b/proto/src/filter.rs
@@ -10,6 +10,15 @@ pub struct AttrPath {
     s: Option<String>,
 }
 
+impl ToString for AttrPath {
+    fn to_string(&self) -> String {
+        match self {
+            Self { a, s: Some(s) } => [a.as_str(), s.as_str()].join("."),
+            Self { a, s: None } => a.to_owned(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ScimFilter {
     Or(Box<ScimFilter>, Box<ScimFilter>),

--- a/proto/src/filter.rs
+++ b/proto/src/filter.rs
@@ -151,6 +151,20 @@ peg::parser! {
     }
 }
 
+impl FromStr for AttrPath {
+    type Err = peg::error::ParseError<peg::str::LineCol>;
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        scimfilter::attrpath(input)
+    }
+}
+
+impl FromStr for ScimFilter {
+    type Err = peg::error::ParseError<peg::str::LineCol>;
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        scimfilter::parse(input)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/proto/src/filter.rs
+++ b/proto/src/filter.rs
@@ -37,6 +37,26 @@ pub enum ScimFilter {
     LessOrEqual(AttrPath, Value),
 }
 
+impl ToString for ScimFilter {
+    fn to_string(&self) -> String {
+        match self {
+            Self::And(this, that) => format!("({} and {})", this.to_string(), that.to_string()),
+            Self::Contains(a, v) => format!("({} co {v})", a.to_string()),
+            Self::EndsWith(a, v) => format!("({} ew {v})", a.to_string()),
+            Self::Equal(a, v) => format!("({} eq {v})", a.to_string()),
+            Self::Greater(a, v) => format!("({} gt {v})", a.to_string()),
+            Self::GreaterOrEqual(a, v) => format!("({} ge {v})", a.to_string()),
+            Self::Less(a, v) => format!("({} lt {v})", a.to_string()),
+            Self::LessOrEqual(a, v) => format!("({} le {v})", a.to_string()),
+            Self::Not(this) => format!("(not ({}))", this.to_string()),
+            Self::NotEqual(a, v) => format!("({} ne {v})", a.to_string()),
+            Self::Or(this, that) => format!("({} or {})", this.to_string(), that.to_string()),
+            Self::Present(a) => format!("({} pr)", a.to_string()),
+            Self::StartsWith(a, v) => format!("({} sw {v})", a.to_string()),
+        }
+    }
+}
+
 // separator()* "(" e:term() ")" separator()* { e }
 
 peg::parser! {

--- a/proto/src/filter.rs
+++ b/proto/src/filter.rs
@@ -1,9 +1,10 @@
 #![allow(warnings)]
 
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::str::FromStr;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AttrPath {
     // Uri: Option<String>,
     a: String,
@@ -19,7 +20,7 @@ impl ToString for AttrPath {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ScimFilter {
     Or(Box<ScimFilter>, Box<ScimFilter>),
     And(Box<ScimFilter>, Box<ScimFilter>),


### PR DESCRIPTION
This is mostly resolving my own feature request in kanidm/kanidm#3035, with the addition of a `ToString` implementation that just always parenthesizes expressions to preserve precedence.

I checked the [Developer Guide](https://kanidm.github.io/kanidm/master/developers/index.html) for any rules or guidance around formatting and pull request structure, and made what I hope to be reasonable assumptions:

- Since this repository does not contain a `rustfmt.toml`, it's formatted using the default formatting rules.
- The changes are one commit per feature, in case any happen to be undesirable or incorrect.
- I didn't see any [DCO](https://developercertificate.org) requirements mentioned, but all commits are signed and include sign-off, just in case.
- I was unable to locate any explicit versioning policy, so I assumed [Semantic Versioning](https://semver.org) and bumped the minor version.
  - Rationale: These changes introduce new functionality, and alter public interfaces (through traits), but do not break compatibility (all additions, no changes or removals).
  - I've seen some projects treat that as a patch-level change in pre-`1.0.0` versions, though. 🤷‍♀️ 

Please let me know if I've missed anything.

Thanks!